### PR TITLE
CHG: upgrade version of reset-client

### DIFF
--- a/dingtalk.gemspec
+++ b/dingtalk.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", "~> 1.7.0"
+  spec.add_dependency "rest-client", "~> 2.0"
   spec.add_dependency "redis", "~> 3.3"
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
原由：qiniu使用的 [reset-client在ruby 2.4.x下面有问题](https://github.com/rest-client/rest-client/issues/569)，但是升级qiniu由于依赖问题，无法升级，dingtalk和qiniu都依赖 reset-client。

其他也有这样的问题
https://github.com/aliyun/aliyun-oss-ruby-sdk/issues/39

我本地也无法使用qiniu（由于reset-client的问题）
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/444876/30247570-3646100e-964a-11e7-8d85-4bd5eb88818c.png">

升级rest-client后正常使用
<img width="1182" alt="image" src="https://user-images.githubusercontent.com/444876/30247587-6e50112a-964a-11e7-9704-4972de870d0b.png">

在我本地已经测试，下图是我修改的gemfile
<img width="476" alt="image" src="https://user-images.githubusercontent.com/444876/30247589-9070bebc-964a-11e7-8afa-06293647e4e0.png">
<img width="253" alt="image" src="https://user-images.githubusercontent.com/444876/30247590-92cbebc8-964a-11e7-88c5-7939083d482b.png">


